### PR TITLE
perf(decode): enable multi-threading

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
@@ -1680,7 +1680,7 @@ namespace WebMConverter
                     }
                 }
 
-                Program.VideoSource = index.VideoSource(path, videotrack);
+                Program.VideoSource = index.VideoSource(path, videotrack, Environment.ProcessorCount);
                 var frame = Program.VideoSource.GetFrame(0); // We're assuming that the entire video has the same settings here, which should be fine. (These options usually don't vary, I hope.)
                 Program.VideoColorRange = frame.ColorRange;
                 Program.VideoInterlaced = frame.InterlacedFrame;


### PR DESCRIPTION
Improves performance of decoding video frames by enabling multi-threading in ffms2. May be less stable than the previous behavior using only a single thread.

* Thread count set to logical processor count
* Significantly improves performance of function FFMSSharp.VideoSource.GetFrame on multiprocessor systems