### PR TITLE
Fix incorrectly cropped subtitles.

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -2453,6 +2453,11 @@ namespace WebMConverter
 
             if (Filters.Dub != null)
                 script.AppendLine(Filters.Dub.ToString());
+            if (Filters.Crop != null) /* If cropping isn't done before subtitles, alignment will be incorrect. */
+            {
+                script.AppendLine(Filters.Crop.ToString());
+                script.AppendLine(new ResizeFilter(Filters.Crop.finalWidth, Filters.Crop.finalHeight).ToString()); 
+            }   
             if (Filters.Subtitle != null)
                 script.AppendLine(Filters.Subtitle.ToString());
             if (Filters.Caption != null)
@@ -2467,12 +2472,7 @@ namespace WebMConverter
             if (Filters.MultipleTrim != null)
                 script.AppendLine(Filters.MultipleTrim.ToString());
             if (Filters.Rate != null)
-                script.AppendLine(Filters.Rate.ToString());
-            if (Filters.Crop != null)
-            {
-                script.AppendLine(Filters.Crop.ToString());
-                script.AppendLine(new ResizeFilter(Filters.Crop.finalWidth, Filters.Crop.finalHeight).ToString()); 
-            }                
+                script.AppendLine(Filters.Rate.ToString());             
             if (Filters.Resize != null)
                 script.AppendLine(Filters.Resize.ToString());
             if (Filters.Reverse != null)


### PR DESCRIPTION
This should fix subtitles being cropped when you take an input video and crop out the top and bottom black bars. I have not tested this code change, but manually editing the Avisynth script to move cropping to the top of the list produces the following results.

Current
![White House Ending webm_snapshot_00 00 000](https://github.com/argorar/WebMConverter/assets/41622989/38c15631-c927-4faf-b919-3eb54dbd9090)
Fixed
![White House Ending2 webm_snapshot_00 00 000](https://github.com/argorar/WebMConverter/assets/41622989/b33a3911-ef22-4e61-9ba9-30ef2e925846)
