### PR TITLE
Add .manifest file to enable long filenames

### DIFF
--- a/WebMConverter.csproj
+++ b/WebMConverter.csproj
@@ -32,6 +32,9 @@
   <PropertyGroup>
     <SignManifests>false</SignManifests>
   </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>WebMConverter.manifest</ApplicationManifest>
+  </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -409,6 +412,7 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
+    <None Include="WebMConverter.manifest" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
@@ -479,6 +483,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Binaries\Win64\ffmpeg.exe">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Binaries\Win64\ffms2.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="icon.ico" />

--- a/WebMConverter.manifest
+++ b/WebMConverter.manifest
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+	<asmv3:application>
+		<asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+			<longPathAware>true</longPathAware>
+		</asmv3:windowsSettings>
+	</asmv3:application>
+</assembly>


### PR DESCRIPTION
Before, the file dialog wouldn't open files with long paths exceeding 260 characters.

Also added and set ffms2.dll to copy over to output as FFMSSharp.FFMS2.Initialize() crashed without it.